### PR TITLE
Fix pip3: command not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN yum update -y \
     git -y \
     && \
    yum clean all \
+   && \
+   yum install --assumeyes python3-pip \
    && :
 
 ENV PATH /usr/local/bin:$PATH


### PR DESCRIPTION
fedora image does not come with pip3 installed. so we need to install python3-pip
by specifying it in Dockerfile `yum install --assumeeyes python3-pip`

Fixes: #13